### PR TITLE
deleteアクションの実装

### DIFF
--- a/app/assets/stylesheets/tweets.css
+++ b/app/assets/stylesheets/tweets.css
@@ -174,10 +174,39 @@ h2{
 .contents-post-show{
   position: absolute;
   margin-left: 550px;
-  margin-top: 50px;
+  margin-top: 90px;
   font-size: 30px;
 }
 
 .show{
   height: 200px;
+}
+
+.delete{
+  position: absolute;
+  margin-left: 700px;
+  display: inline-block;
+  padding: 0.5em 1em;
+  text-decoration: none;
+  background:#67c5ff ;
+  border-bottom: solid 4px #627295;
+  border-radius: 3px;
+  margin-top: 50px;
+}
+
+.delete:active{
+  -webkit-transform: translateY(4px);
+  transform: translateY(4px);
+  border-bottom: none;
+}
+
+.delete a{
+  text-decoration: none;
+  color: white;
+}
+
+h4{
+  margin-left: 500px;
+  margin-top: 30px;
+  font-size: 30px;
 }

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -15,6 +15,11 @@ class TweetsController < ApplicationController
     Tweet.create(tweet_params)
   end
 
+  def destroy
+    tweet = Tweet.find(params[:id])
+    tweet.destroy
+  end
+
   private
   def tweet_params
     params.require(:tweet).permit(:name, :image, :text)

--- a/app/views/tweets/destroy.html.erb
+++ b/app/views/tweets/destroy.html.erb
@@ -1,0 +1,15 @@
+<div class = "contents-center">
+  <div class="success">
+    <h4>
+      Post has been deleted
+    </h4>
+    <a class="btn" href="/">Return to list of posts</a>
+  </div>
+</div>
+</div>
+<div class = "contents-side">
+      <div class = "contents-side-left">
+      </div>
+      <div class = "contents-side-right">
+      </div>
+    </div>

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -8,6 +8,9 @@
     <span data-livestamp="<%=@tweet.updated_at.strftime("%Y/%m/%d %H:%M %Z")%>"></span>
       </div>
     </div>
+    <div class = "delete">
+     <%= link_to '削除', "/tweets/#{@tweet.id}", method: :delete %>
+     </div>
       <div class = "contents-post-show">
         <%= @tweet.text%>
         <br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   root to: 'tweets#index'
-  resources :tweets, only: [:index, :new, :create, :show]
+  resources :tweets, only: [:index, :new, :create, :show, :destroy]
 end


### PR DESCRIPTION
# What
投稿を削除する機能を追加

# Why
投稿が削除できることによって誤ったものを訂正できる。この機能はセキュリティ面から見ても「重要なため、必須と考えられる。