### PR TITLE
ニックネームの編集、ログインの編集

### DIFF
--- a/app/assets/stylesheets/tweets.css
+++ b/app/assets/stylesheets/tweets.css
@@ -63,7 +63,7 @@
 .contents-side{
   display: flex;
   justify-content: space-between;
-  height: 60px;
+  height: 200px;
 }
 
 .contents-side-left{
@@ -367,8 +367,8 @@ h5{
 
 .contents-date2{
   position: absolute;
-  width: 100px;
-  margin-left: 560px;
+  width: 200px;
+  margin-left: 360px;
   margin-top: 30px;
   color: gray;
 }
@@ -377,4 +377,10 @@ h5{
   position: absolute;
   margin-left: 600px;
   margin-top: 60px;
+}
+
+h5{
+  position: absolute;
+  margin-left: 620px;
+  font-size: 20px;
 }

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -32,7 +32,7 @@ class TweetsController < ApplicationController
 
   private
   def tweet_params
-    params.require(:tweet).permit(:name, :image, :text).merge(user_id: current_user.id)
+       params.require(:tweet).permit(:image, :text).merge(user_id: current_user.id)
   end
 
   def move_to_index

--- a/app/views/tweets/edit.html.erb
+++ b/app/views/tweets/edit.html.erb
@@ -3,8 +3,6 @@
         <h3>
           Tweet-Edit
         </h3>
-        <%= form.text_field :name, placeholder: "Nickname" %>
-        <br>
         <%= form.file_field :image %>
         <i class="far fa-image"></i>
         <br>

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -3,7 +3,7 @@
     <div class = "contents-center">
     <div class = "contents-name-date">
       <div class = "contents-name">
-        <%= tweet.name%>    
+       <%= tweet.user.nickname %>   
       </div>
       <div class = "contents-date">
     <span data-livestamp="<%=tweet.updated_at.strftime("%Y/%m/%d %H:%M %Z")%>"></span>

--- a/app/views/tweets/new.html.erb
+++ b/app/views/tweets/new.html.erb
@@ -4,8 +4,6 @@
         <h3>
           Tweet
         </h3>
-        <%= form.text_field :name, placeholder: "Nickname" %>
-        <br>
         <%= form.file_field :image %>
         <i class="far fa-image"></i>
         <br>

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -2,18 +2,20 @@
     <div class = "contents-center">
     <div class = "contents-name-date">
       <div class = "contents-name-show">
-        <%= @tweet.name%>    
+        <%= @tweet.user.nickname %>    
       </div>
       <div class = "contents-date-show">
     <span data-livestamp="<%=@tweet.updated_at.strftime("%Y/%m/%d %H:%M %Z")%>"></span>
       </div>
     </div>
+    <% if user_signed_in? && current_user.id == @tweet.user_id %>
     <div class = "edit">
       <%= link_to '編集', "/tweets/#{@tweet.id}/edit", method: :get %>
     </div>
     <div class = "delete">
      <%= link_to '削除', "/tweets/#{@tweet.id}", method: :delete %>
      </div>
+     <% end %>
       <div class = "contents-post-show">
         <%= @tweet.text%>
         <br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,14 +1,10 @@
 
+<h5><%= @nickname%>さんの投稿</h1>
+<% @tweets.each do |tweet| %>
 
-  <% @tweets.each do |tweet| %>
-<div class = "contents-center2">
-<div class="name-index">
-  <p><%= @nickname %>さんの投稿一覧</p>
-  </div>
+<div class = "contents-oya">
+    <div class = "contents-center2">
     <div class = "contents-name-date">
-      <div class = "contents-name2">
-        <%= tweet.name%>    
-      </div>
       <div class = "contents-date2">
     <span data-livestamp="<%=tweet.updated_at.strftime("%Y/%m/%d %H:%M %Z")%>"></span>
       </div>
@@ -25,4 +21,6 @@
       </div>
       <div class = "contents-side-right">
       </div>
-  <% end %>
+    </div>
+</div>
+<% end %>

--- a/db/migrate/20200517063429_remove_name_from_tweets.rb
+++ b/db/migrate/20200517063429_remove_name_from_tweets.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromTweets < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :tweets, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_16_044506) do
+ActiveRecord::Schema.define(version: 2020_05_17_063429) do
 
   create_table "tweets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name"
     t.string "text"
     t.text "image"
     t.datetime "created_at", null: false


### PR DESCRIPTION
# What
ニックネームの編集に関しては、投稿者が自動的にログインしているユーザーに紐づくように表示させている。また、ログインしているユーザーが投稿した記事のみ、編集、削除ができるようにした。

# Why
セキュリティの向上、便意性の向上のため。